### PR TITLE
[QOL-8536] fix type sniffing bug for files containing 'C '

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,6 +10,7 @@ format = pylint
 show_source = True
 
 max-complexity = 10
+max-line-length = 127
 
 # List ignore rules one per line.
 ignore =

--- a/ckanext/resource_type_validation/resources/resource_types.json
+++ b/ckanext/resource_type_validation/resources/resource_types.json
@@ -19,6 +19,7 @@
             "model/mtl",
             "text/*"
         ],
+        "text/x-fortran": ["text/csv"],
         "application/xml": [
             "application/rdf+xml",
             "application/vnd.google-earth.kml+xml"

--- a/ckanext/resource_type_validation/test_mime_type_validation.py
+++ b/ckanext/resource_type_validation/test_mime_type_validation.py
@@ -44,6 +44,7 @@ sample_files = [
     ('example.asc', 'ASC', 'application/x-ascii-grid'),
     ('example.cdf', 'CDF', ['application/x-cdf', 'application/x-netcdf']),
     ('foo.csv', 'CSV', 'text/csv'),
+    ('fortran-bug.csv', 'CSV', 'text/csv'),
     ('example.docx', 'DOCX', 'application/'
      'vnd.openxmlformats-officedocument.wordprocessingml.document'),
     ('sample.ecw', 'ECW', 'application/octet-stream'),

--- a/test/resources/fortran-bug.csv
+++ b/test/resources/fortran-bug.csv
@@ -1,0 +1,2 @@
+Category,Category name
+C and FS and YJ,Child and Family Services and Youth Justice


### PR DESCRIPTION
- https://thedailywtf.com/articles/you-re-not-my-mime-type has details of the bug.
Essentially, libmagic sees a line starting with 'C ' and reports that the file is Fortran code, even if there are a dozen other types it could (and is more likely to) be.