### PR TITLE
[QOL-7544] handle link resources using placeholder empty FileStorage

### DIFF
--- a/ckanext/resource_type_validation/resource_type_validation.py
+++ b/ckanext/resource_type_validation/resource_type_validation.py
@@ -85,7 +85,8 @@ class ResourceTypeValidator:
 
     def validate_resource_mimetype(self, resource):
         upload_field_storage = resource.get('upload', None)
-        if isinstance(upload_field_storage, ALLOWED_UPLOAD_TYPES):
+        if isinstance(upload_field_storage, ALLOWED_UPLOAD_TYPES) \
+                and upload_field_storage.filename:
             filename = upload_field_storage.filename
 
             mime = magic.Magic(mime=True)


### PR DESCRIPTION
Link resources may (on CKAN 2.9) create a FileStorage object representing a zero-length binary stream, but they should not be treated as uploads.