### PR TITLE
Allow overrides "application/csv" - "text/csv"

### DIFF
--- a/ckanext/resource_type_validation/resources/resource_types.json
+++ b/ckanext/resource_type_validation/resources/resource_types.json
@@ -15,10 +15,12 @@
             "application/xml",
             "application/json",
             "application/rdf+xml",
+            "application/csv",
             "application/vnd.google-earth.kml+xml",
             "model/mtl",
             "text/*"
         ],
+        "text/csv": ["application/csv"],
         "text/x-fortran": ["text/csv"],
         "application/xml": [
             "application/rdf+xml",


### PR DESCRIPTION
This extension uses magic module which uses libmagic library. This library provides a 'magic_file' function and `file` tool, which is used to find out a file mime type. I'm using Ubuntu 20.04 and the latest stable libmagic version has a bug. The CSV file mime type defines as "application/csv" which isn't a valid mime type. Because you are using `ubuntu-latest` container for data-qld workflow, it fails to create/update a resource in tests. I believe, it's the easiest solution here. 