### PR TITLE
Qol 9474 fix mime magic error

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 # @see https://flake8.pycqa.org/en/latest/user/configuration.html?highlight=.flake8
 
-exclude =
+exclude = venv
 
 # Extended output format.
 format = pylint

--- a/ckanext/resource_type_validation/resource_type_validation.py
+++ b/ckanext/resource_type_validation/resource_type_validation.py
@@ -97,6 +97,8 @@ class ResourceTypeValidator:
             upload_file.seek(0, os.SEEK_SET)
             LOG.debug('Upload sniffing indicates MIME type %s',
                       sniffed_mimetype)
+            # print('Upload sniffing indicates MIME type ',
+            #           sniffed_mimetype, upload_file, '\r\n')
         elif IS_REMOTE_URL_PATTERN.search(
                 resource.get('url', 'http://example.com')
         ):
@@ -154,11 +156,19 @@ class ResourceTypeValidator:
             and format_mimetype not in self.generic_mimetypes\
             or filename_mimetype in self.archive_mimetypes
 
-        best_guess_mimetype = resource['mimetype'] = self.coalesce_mime_types(
-            [filename_mimetype, format_mimetype, sniffed_mimetype,
-             claimed_mimetype],
-            allow_override=allow_override
-        )
+        try:
+            best_guess_mimetype = resource['mimetype'] = self.coalesce_mime_types(
+                [filename_mimetype, format_mimetype, sniffed_mimetype,
+                 claimed_mimetype],
+                allow_override=allow_override
+            )
+        except ValidationError as e:
+            LOG.debug("Best guess at MIME type failed %s - upload type: %s format type: %s sniffed: %s claimed: %s",
+                      resource.get('url'), filename_mimetype, format_mimetype, sniffed_mimetype, claimed_mimetype)
+            # print(resource.get('url'), ' upload type: ', filename_mimetype,' format type: ', format_mimetype,
+            # "sniffed: ", sniffed_mimetype, " claimed: ", claimed_mimetype, 'failed', '\r\n')
+            raise e
+
         LOG.debug("Best guess at MIME type is %s", best_guess_mimetype)
         if not self.is_mimetype_allowed(best_guess_mimetype):
             raise ValidationError(

--- a/ckanext/resource_type_validation/resources/resource_types.json
+++ b/ckanext/resource_type_validation/resources/resource_types.json
@@ -9,6 +9,12 @@
     ],
     "allowed_overrides": {
         "application/octet-stream": ["*"],
+        "application/x-ole-storage": [
+            "application/msword",
+            "application/vnd.ms-powerpoint",
+            "application/vnd.ms-excel",
+            "application/vnd.ms-powerpoint"
+        ],
         "text/plain": [
             "application/sparql-query",
             "application/x-ascii-grid",
@@ -41,8 +47,11 @@
         ["text/rtf", "text/richtext", "application/rtf", "application/x-rtf"],
         ["text/xml", "application/xml"],
         ["application/x-cdf", "application/x-netcdf"],
+        ["application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+        ["application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"],
         ["application/msaccess", "application/x-msaccess", "application/vnd.msaccess", "application/vnd.ms-access", "application/mdb", "application/x-mdb"],
-        ["application/CDFV2", "application/CDFV2-unknown"]
+        ["application/CDFV2", "application/CDFV2-unknown"],
+        ["application/x-sqlite3" ,"application/vnd.sqlite3"]
     ],
     "generic_types": ["application/octet-stream", "text/plain"],
     "archive_types": ["application/zip", "application/x-tar"],

--- a/ckanext/resource_type_validation/test_mime_type_validation.py
+++ b/ckanext/resource_type_validation/test_mime_type_validation.py
@@ -5,8 +5,13 @@
 
 import unittest
 
-from .resource_type_validation import ResourceTypeValidator,\
-    normalize_whitespace
+if __name__ == '__main__':
+    from resource_type_validation import ResourceTypeValidator, \
+        normalize_whitespace
+else:
+    from .resource_type_validation import ResourceTypeValidator, \
+        normalize_whitespace
+
 from ckan.logic import ValidationError
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
 
@@ -47,14 +52,16 @@ sample_files = [
     ('fortran-bug.csv', 'CSV', 'text/csv'),
     ('example.docx', 'DOCX', 'application/'
      'vnd.openxmlformats-officedocument.wordprocessingml.document'),
+    ('example.docx', 'DOCX', ['application/msword', 'application/'
+     'vnd.openxmlformats-officedocument.wordprocessingml.document']),
     ('sample.ecw', 'ECW', 'application/octet-stream'),
     ('example.kmz', 'KMZ', 'application/vnd.google-earth.kmz'),
-    ('example.xml', 'XML', 'text/xml'),
+    ('example.xml', 'XML', ['text/xml', 'application/xml']),
     ('dummy.pdf', 'PDF', 'application/pdf'),
     ('zoning.gdb', 'GDB', 'application/x-filegdb'),
     ('sample.geojson', 'GeoJSON', 'application/json'),
     ('ntf_nord.geotiff', 'GeoTIFF', 'image/tiff'),
-    ('example.gpkg', 'GPKG', 'application/x-sqlite3'),
+    ('example.gpkg', 'GPKG', ['application/x-sqlite3', 'application/vnd.sqlite3']),
     ('example.gpx', 'GPX', 'application/xml'),
     ('example.html', 'HTML', 'text/html'),
     ('sample1.jp2', 'JP2', 'image/jp2'),
@@ -73,6 +80,8 @@ sample_files = [
     ('example.wmts', 'WMTS', 'application/xml'),
     ('example.xlsx', 'XLSX', 'application/'
      'vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
+    ('example.xlsx', 'XLSX', ['application/vnd.ms-excel', 'application/'
+     'vnd.openxmlformats-officedocument.spreadsheetml.sheet']),
     ('example.doc', 'DOC', 'application/msword'),
     ('example.json', 'JSON', 'application/json'),
     ('example.kml', 'KML', 'application/vnd.google-earth.kml+xml'),
@@ -177,6 +186,7 @@ class TestMimeTypeValidation(unittest.TestCase):
                     assert_function = self.assertIn
                 else:
                     assert_function = self.assertEqual
+                # print(resource, expected_type, error_msg)
                 assert_function(
                     resource['mimetype'], expected_type, error_msg)
             finally:


### PR DESCRIPTION
[QOL-9474 make mime type sniffing a lenient on mac and Amazon Linux 2 (AL2)](https://github.com/qld-gov-au/ckanext-resource-type-validation/commit/32f5512ed5cfb5d0285caf768c19d89f3ecf1292) 