### PR TITLE
[QOLDEV-725] ignore same-site URLs that aren't uploads

### DIFF
--- a/ckanext/resource_type_validation/resource_type_validation.py
+++ b/ckanext/resource_type_validation/resource_type_validation.py
@@ -13,7 +13,6 @@ import six
 
 from ckan.lib.uploader import ALLOWED_UPLOAD_TYPES
 from ckan.logic import ValidationError
-from ckan.plugins.toolkit import config
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
 
 LOG = getLogger(__name__)
@@ -69,6 +68,10 @@ class ResourceTypeValidator:
             'ckanext.resource_validation.support_contact',
             'the site owner.'
         )
+        self.file_download_pattern = re.compile(
+            config.get('ckan.site_url', '') + '(/[-_a-z0-9]+){2}/resource/[-0-9a-f]+/download',
+            re.IGNORECASE
+        )
 
         self.invalid_upload_message = normalize_whitespace(
             '''This file type is not supported.
@@ -107,7 +110,7 @@ class ResourceTypeValidator:
             # print('Upload sniffing indicates MIME type ',
             #           sniffed_mimetype, upload_file, '\r\n')
         elif IS_REMOTE_URL_PATTERN.search(
-                resource.get('url', 'http://example.com').replace(config.get('ckan.site_url', ''), '')
+                self.file_download_pattern.sub('', resource.get('url', 'http://example.com'))
         ):
             LOG.debug('%s [%s] is not an uploaded resource, skipping validation',
                       resource.get('id', 'New resource'), resource.get('url'))

--- a/ckanext/resource_type_validation/test_mime_type_validation.py
+++ b/ckanext/resource_type_validation/test_mime_type_validation.py
@@ -117,6 +117,11 @@ sample_file_rejections = [
     ('eicar.com.pdf', 'example.zip', 'ZIP'),
 ]
 
+sample_links = [
+    'http://example.com/foo.csv',
+    'http://ckan:5000/dataset/foo'
+]
+
 
 class TestMimeTypeValidation(unittest.TestCase):
     """ Test that potential MIME type candidates are correctly coalesced
@@ -125,7 +130,7 @@ class TestMimeTypeValidation(unittest.TestCase):
 
     def setUp(self):
         self.validator = ResourceTypeValidator()
-        self.validator.configure({})
+        self.validator.configure({'ckan.site_url': 'http://ckan:5000/'})
 
     def test_equal_types(self):
         """ Test that equal types are treated as interchangeable.
@@ -229,9 +234,10 @@ class TestMimeTypeValidation(unittest.TestCase):
         """ Test that link-type resources do not have their file types
         validated, since they're not under our control.
         """
-        resource = {'url': 'http://example.com/foo.csv', 'format': 'PDF'}
-        self.validator.validate_resource_mimetype(resource)
-        self.assertIsNone(resource.get('mimetype'))
+        for url in sample_links:
+            resource = {'url': url, 'format': 'HTML'}
+            self.validator.validate_resource_mimetype(resource)
+            self.assertIsNone(resource.get('mimetype'))
 
     # Test error messages
 


### PR DESCRIPTION
- This also gives us the chance to precompile the regex we use to detect download URLs.