### PR TITLE
QOLDEV-2091 update tests for CKAN 2.12

### DIFF
--- a/.docker/Dockerfile-template.ckan
+++ b/.docker/Dockerfile-template.ckan
@@ -24,8 +24,7 @@ COPY bin/ckan_cli /usr/bin/
 RUN chmod +x "${APP_DIR}"/bin/*.sh /usr/bin/ckan_cli
 
 RUN (which ps && which wget) || (apt-get update && apt-get install -y procps wget)
-RUN pip install uv pyasyncore standard-smtpd
-
+RUN pip install uv
 
 USER "$ORIGINAL_USER"
 

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -11,8 +11,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install requirements

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'qld-gov-au/ckanext-resource-type-validation'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -103,7 +103,7 @@ jobs:
           echo "url=${url}" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build package ${{ steps.version.outputs.reponame }} @ ${{ steps.version.outputs.version }}
         run: |

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -28,6 +28,9 @@ jobs:
     name: ${{ matrix.experimental && '**Fail_Ignored** ' || '' }} Check types ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest
     steps:
+      - name: checkout plugin
+        uses: actions/checkout@v7
+
       - name: checkout ckan
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -28,19 +28,18 @@ jobs:
     name: ${{ matrix.experimental && '**Fail_Ignored** ' || '' }} Check types ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - name: checkout ckan
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ckan/ckan
           ref: ${{ matrix.ckan-version }}
           path: ckan
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Preserve $HOME set in the container
         run: echo HOME=/root >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         continue-on-error: ${{ matrix.experimental }}
         timeout-minutes: 2
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-behaving==3.2.1
 Appium-Python-Client==2.10.1
 ckanapi>=4.7
 ckan
@@ -16,3 +15,5 @@ requests>=2.32.0 # not directly required, pinned by Snyk to avoid a vulnerabilit
 selenium<4.10
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+
+git+https://github.com/qld-gov-au/behaving.git@QOLDEV-2078-ckan-2.12#egg=behaving

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,4 +16,4 @@ selenium<4.10
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
-git+https://github.com/qld-gov-au/behaving.git@QOLDEV-2078-ckan-2.12#egg=behaving
+git+https://github.com/qld-gov-au/behaving.git@aff702e#egg=behaving

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 Appium-Python-Client==2.10.1
+behaving==3.3.*
 ckanapi>=4.7
 ckan
 ckantoolkit>=0.0.4
@@ -16,4 +17,3 @@ selenium<4.10
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
-git+https://github.com/qld-gov-au/behaving.git@f9e8d65#egg=behaving

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,4 +16,4 @@ selenium<4.10
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
-git+https://github.com/qld-gov-au/behaving.git@aff702e#egg=behaving
+git+https://github.com/qld-gov-au/behaving.git@3aa1574#egg=behaving

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,4 +16,4 @@ selenium<4.10
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
-git+https://github.com/qld-gov-au/behaving.git@3aa1574#egg=behaving
+git+https://github.com/qld-gov-au/behaving.git@f9e8d65#egg=behaving


### PR DESCRIPTION
- Update Behaving to handle Python 3.12+ instead of relying on obsolete 'asyncore'
- Update GitHub workflow actions to later versions